### PR TITLE
fix(XXXL-60634): Adjust breadcumbs Github-Server link

### DIFF
--- a/cmd/doc/main.go
+++ b/cmd/doc/main.go
@@ -92,6 +92,7 @@ type baseData struct {
 
 type docData struct {
 	Page        pageData
+	Server      string
 	Repo        string
 	Tag         string
 	At          string
@@ -396,6 +397,7 @@ func doc(w http.ResponseWriter, r *http.Request) {
 
 	if err := page.HTML(w, http.StatusOK, "doc", docData{
 		Page:        pageData,
+		Server:      server,
 		Repo:        strings.Join([]string{org, repo}, "/"),
 		Tag:         foundTag,
 		Group:       gvk.Group,

--- a/template/navbar-doc.html
+++ b/template/navbar-doc.html
@@ -1,4 +1,4 @@
 <ul class="navbar-nav d-none d-md-flex">
-    <li class="breadcrumb-item"><a href="/github.com/{{ .Repo }}@{{ .Tag }}">{{ .Repo }}@{{ .Tag }}</a></li>
+    <li class="breadcrumb-item"><a href="/{{ .Server }}/{{ .Repo }}@{{ .Tag }}">{{ .Repo }}@{{ .Tag }}</a></li>
     <li class="breadcrumb-item active" aria-current="page"><a href="#">{{ .Kind }}.{{ .Version }}.{{ .Group }}</a></li>
 </ul>


### PR DESCRIPTION
This PR adjusts the breadcrumbs in the navbar to show actual Github server links instead of hardcoded "github.com".